### PR TITLE
Typo in the navigation menu of the docs

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -57,4 +57,4 @@
 - [Build System](build-system.md)
 - [Boot FS](bootfs.md)
 - [Changelog](changelog.md)
-- [Conding Style Guides](coding-styles.md)
+- [Coding Style Guides](coding-styles.md)


### PR DESCRIPTION
There was a small typo, 'conding' -> 'coding', on the side navigation bar in docs.